### PR TITLE
[mixer_speaker] Add task debounce

### DIFF
--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -11,14 +11,14 @@
 #include <array>
 #include <cstring>
 
-namespace esphome {
-namespace mixer_speaker {
+namespace esphome::mixer_speaker {
 
 static const UBaseType_t MIXER_TASK_PRIORITY = 10;
 
 static const uint32_t STOPPING_TIMEOUT_MS = 5000;
 static const uint32_t TRANSFER_BUFFER_DURATION_MS = 50;
 static const uint32_t TASK_DELAY_MS = 25;
+static const uint32_t MIXER_AUTO_STOP_DEBOUNCE_MS = 200;
 
 static const size_t TASK_STACK_SIZE = 4096;
 
@@ -471,6 +471,7 @@ void MixerSpeaker::loop() {
     this->task_.deallocate();
     ESP_LOGD(TAG, "Stopped");
     xEventGroupClearBits(this->event_group_, MIXER_TASK_ALL_BITS);
+    this->all_stopped_since_ms_ = 0;
   }
 
   if (this->task_.is_created()) {
@@ -483,8 +484,18 @@ void MixerSpeaker::loop() {
     }
 
     if (all_stopped) {
-      // Send stop command signal to the mixer task since no source speakers are active
-      xEventGroupSetBits(this->event_group_, MIXER_TASK_COMMAND_STOP);
+      if (this->all_stopped_since_ms_ == 0) {
+        this->all_stopped_since_ms_ = millis();
+      } else if ((millis() - this->all_stopped_since_ms_) >= MIXER_AUTO_STOP_DEBOUNCE_MS) {
+        // Send stop command only after a short debounce to avoid stop/start thrash during rapid seeks.
+        xEventGroupSetBits(this->event_group_, MIXER_TASK_COMMAND_STOP);
+      }
+    } else {
+      this->all_stopped_since_ms_ = 0;
+      // New activity detected; clear any stale auto-stop request before it can stop the running task.
+      if (event_group_bits & MIXER_TASK_COMMAND_STOP) {
+        xEventGroupClearBits(this->event_group_, MIXER_TASK_COMMAND_STOP);
+      }
     }
   } else {
     // Task is fully stopped and cleaned up, check if we can disable loop
@@ -514,6 +525,9 @@ esp_err_t MixerSpeaker::start(audio::AudioStreamInfo &stream_info) {
   }
 
   this->enable_loop_soon_any_context();  // ensure loop processes command
+
+  // Starting a new stream supersedes any previously queued stop request.
+  xEventGroupClearBits(this->event_group_, MIXER_TASK_COMMAND_STOP);
 
   uint32_t event_bits = xEventGroupGetBits(this->event_group_);
   if (!(event_bits & MIXER_TASK_COMMAND_START)) {
@@ -755,7 +769,6 @@ void MixerSpeaker::audio_mixer_task(void *params) {
   vTaskSuspend(nullptr);  // Suspend this task indefinitely until the loop method deletes it
 }
 
-}  // namespace mixer_speaker
-}  // namespace esphome
+}  // namespace esphome::mixer_speaker
 
 #endif

--- a/esphome/components/mixer/speaker/mixer_speaker.h
+++ b/esphome/components/mixer/speaker/mixer_speaker.h
@@ -14,8 +14,7 @@
 
 #include <atomic>
 
-namespace esphome {
-namespace mixer_speaker {
+namespace esphome::mixer_speaker {
 
 /* Classes for mixing several source speaker audio streams and writing it to another speaker component.
  *  - Volume controls are passed through to the output speaker
@@ -200,9 +199,9 @@ class MixerSpeaker : public Component {
   optional<audio::AudioStreamInfo> audio_stream_info_;
 
   std::atomic<uint32_t> frames_in_pipeline_{0};  // Frames written to output but not yet played
+  uint32_t all_stopped_since_ms_{0};             // Debounce transient all-stopped windows before stopping task
 };
 
-}  // namespace mixer_speaker
-}  // namespace esphome
+}  // namespace esphome::mixer_speaker
 
 #endif


### PR DESCRIPTION
# What does this implement/fix?

While testing #8065, I observed that the mixer speaker task could experience stop/start thrashing during rapid seeks or transient gaps when all source speakers briefly report as stopped.

**Changes:**

- Added a 200ms debounce before auto-stopping the mixer task. Instead of immediately sending `MIXER_TASK_COMMAND_STOP` when all source speakers are inactive, it now records the timestamp when the "all stopped" state was first detected (`all_stopped_since_ms_`) and only issues the stop command after 200ms of continuous inactivity.

- Clears stale stop requests on new activity. If any source speaker becomes active again during the debounce window, the timer resets and any already-queued `MIXER_TASK_COMMAND_STOP` bit is cleared from the event group.

- Clears stop on new `start()`. When `start()` is called, any previously queued stop request is explicitly cleared to prevent a race where a stale stop could kill a freshly started stream.

- Minor style cleanup: Collapsed nested `namespace esphome { namespace mixer_speaker {` into the C++17 `namespace esphome::mixer_speaker {` form in both `.cpp` and `.h` files.

New member: `uint32_t all_stopped_since_ms_{0}` on `MixerSpeaker` tracks when the all-stopped condition was first observed, reset to 0 on task stop or new activity.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
